### PR TITLE
Fix package name from "react-placards" to "react-upload-box" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 ```javascript
 
   import React, { useState } from 'react';
-  import { ReactUpload } from 'react-placards'
+  import { ReactUpload } from 'react-upload-box'
   function App() {
     const [percentage, setPercentage] = useState(0);
     const [pause, setPause] = useState(false);


### PR DESCRIPTION
Great job on the component! I was going through the documentation and found this mistake. 